### PR TITLE
Center third-person camera on vehicle

### DIFF
--- a/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
+++ b/mccore/src/main/java/minecrafttransportsimulator/entities/components/AEntityB_Existing.java
@@ -282,20 +282,29 @@ public abstract class AEntityB_Existing extends AEntityA_Base {
                 prevRiderCameraPosition.set(riderCameraPosition);
                 CameraMode cameraMode = InterfaceManager.clientInterface.getCameraMode();
                 if (CameraSystem.activeCamera == null && cameraMode != CameraMode.FIRST_PERSON) {
-                    riderCameraPosition.set(riderEyePosition);
-
-                    //Adjust eye position to account for zoom settings.
                     int zoomRequired = 4 + zoomLevel;
                     riderTempPoint.set(0, 0, cameraMode == CameraMode.THIRD_PERSON ? -zoomRequired : zoomRequired).rotate(rider.getOrientation());
                     riderEyePosition.add(riderTempPoint);
 
-                    //Check if camera should be where eyes are, or somewhere different.
                     int cameraZoomRequired = 4 - InterfaceManager.clientInterface.getCameraDefaultZoom() + zoomLevel;
-                    if (zoomRequired != cameraZoomRequired) {
+                    if (this instanceof minecrafttransportsimulator.entities.instances.PartSeat) {
+                        minecrafttransportsimulator.entities.instances.PartSeat seat = (minecrafttransportsimulator.entities.instances.PartSeat) this;
+                        if (seat.vehicleOn != null) {
+                            riderCameraPosition.set(seat.vehicleOn.position);
+                        } else {
+                            riderCameraPosition.set(riderEyePosition);
+                        }
                         riderTempPoint.set(0, 0, cameraMode == CameraMode.THIRD_PERSON ? -cameraZoomRequired : cameraZoomRequired).rotate(rider.getOrientation());
                         riderCameraPosition.add(riderTempPoint);
+                        riderCameraPosition.interpolate(prevRiderCameraPosition, 0.25);
                     } else {
-                        riderCameraPosition.add(riderTempPoint);
+                        riderCameraPosition.set(riderEyePosition);
+                        if (zoomRequired != cameraZoomRequired) {
+                            riderTempPoint.set(0, 0, cameraMode == CameraMode.THIRD_PERSON ? -cameraZoomRequired : cameraZoomRequired).rotate(rider.getOrientation());
+                            riderCameraPosition.add(riderTempPoint);
+                        } else {
+                            riderCameraPosition.add(riderTempPoint);
+                        }
                     }
                 } else {
                     riderCameraPosition.set(riderEyePosition);


### PR DESCRIPTION
## Summary
- shift third-person camera pivot to vehicle center
- interpolate camera position for smoother movement
- fix instanceof cast to be Java 8 compatible

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686688da533c832b97b039ddd6711aff